### PR TITLE
[Feat/#7] : 카카오 로그인, 유저 정보 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,17 @@ dependencies {
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// Web Client
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ssg_tab/SsgTabApplication.java
+++ b/src/main/java/com/example/ssg_tab/SsgTabApplication.java
@@ -2,8 +2,10 @@ package com.example.ssg_tab;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SsgTabApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/ssg_tab/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/controller/UserController.java
@@ -1,0 +1,39 @@
+package com.example.ssg_tab.domain.user.controller;
+
+import com.example.ssg_tab.domain.test.dto.response.TestResponse;
+import com.example.ssg_tab.domain.user.dto.response.UserResponse;
+import com.example.ssg_tab.domain.user.entity.User;
+import com.example.ssg_tab.domain.user.service.UserService;
+import com.example.ssg_tab.global.apiPayload.ApiResponse;
+import com.example.ssg_tab.global.apiPayload.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user")
+@Tag(name = "User", description = "사용자 관련 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping(value = "/", produces = "application/json")
+    @Operation(summary = "유저 정보 조회 API", description = "로그인한 사용자의 유저 정보를 조회합니다.")
+    public ApiResponse<UserResponse.UserInfoResponse> getUserInfo(@AuthenticationPrincipal UserDetails userDetails){
+
+        Long uid = Long.valueOf(userDetails.getUsername());   // 유저 ID
+        UserResponse.UserInfoResponse response = userService.getUserInfo(uid);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/converter/UserConverter.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/converter/UserConverter.java
@@ -1,0 +1,18 @@
+package com.example.ssg_tab.domain.user.converter;
+
+import com.example.ssg_tab.domain.user.dto.response.UserResponse;
+import com.example.ssg_tab.domain.user.entity.User;
+
+public class UserConverter {
+
+    public static UserResponse.UserInfoResponse toUserInfoResponse(User user) {
+
+        return UserResponse.UserInfoResponse.builder()
+                .id(user.getId())
+                .nickname(user.getNickname())
+                .email(user.getEmail())
+                .profileImageUrl(user.getProfileImageUrl())
+                .build();
+
+    }
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/dto/response/UserResponse.java
@@ -1,0 +1,33 @@
+package com.example.ssg_tab.domain.user.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.persistence.Column;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.stereotype.Controller;
+
+public class UserResponse {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "사용자 정보 조회")
+    public static class UserInfoResponse {
+
+        @Schema(description = "유저 ID")
+        private Long id;
+
+        @Schema(description = "유저 닉네임")
+        private String nickname;
+
+        @Schema(description = "유저 이메일")
+        private String email;
+
+        @Schema(description = "유저 프로필 이미지")
+        private String profileImageUrl;
+
+    }
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/entity/User.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/entity/User.java
@@ -1,0 +1,38 @@
+package com.example.ssg_tab.domain.user.entity;
+
+import com.example.ssg_tab.domain.user.entity.enums.UserRole;
+import com.example.ssg_tab.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Table(name = "users")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(unique = true)
+    private Long socialId;
+
+    // user 기본 정보
+    @Column(name = "nickname", length = 100)
+    private String nickname;
+    @Column(name = "email", unique = true, length = 255)
+    private String email;
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole role;
+
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/entity/enums/UserRole.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/entity/enums/UserRole.java
@@ -1,0 +1,6 @@
+package com.example.ssg_tab.domain.user.entity.enums;
+
+public enum UserRole {
+    USER,   // 일반
+    ADMIN   // 관리자
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/repository/UserRepository.java
@@ -1,0 +1,13 @@
+package com.example.ssg_tab.domain.user.repository;
+
+import com.example.ssg_tab.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findBySocialId(Long socialId);
+    Optional<User> findByEmail(String email);
+
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/service/UserService.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/UserService.java
@@ -1,0 +1,15 @@
+package com.example.ssg_tab.domain.user.service;
+
+import com.example.ssg_tab.domain.user.dto.response.UserResponse;
+import com.example.ssg_tab.domain.user.entity.User;
+import com.example.ssg_tab.global.auth.info.KakaoUserInfo;
+
+import java.util.Optional;
+
+public interface UserService {
+
+    User createUser(KakaoUserInfo userInfo);
+
+    UserResponse.UserInfoResponse getUserInfo(Long userId);
+
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,46 @@
+package com.example.ssg_tab.domain.user.service;
+
+import com.example.ssg_tab.domain.user.converter.UserConverter;
+import com.example.ssg_tab.domain.user.dto.response.UserResponse;
+import com.example.ssg_tab.domain.user.entity.User;
+import com.example.ssg_tab.domain.user.entity.enums.UserRole;
+import com.example.ssg_tab.domain.user.repository.UserRepository;
+import com.example.ssg_tab.global.apiPayload.status.ErrorStatus;
+import com.example.ssg_tab.global.auth.info.KakaoUserInfo;
+import com.example.ssg_tab.global.exception.GeneralException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public User createUser(KakaoUserInfo userInfo) {
+
+        User created = User.builder()
+                .socialId(userInfo.id())
+                .nickname(userInfo.getNickname())
+                .email(userInfo.getEmail())
+                .role(UserRole.USER)
+                .profileImageUrl(userInfo.getProfileImageUrl())
+                .build();
+        return userRepository.save(created);
+
+    }
+
+    @Override
+    public UserResponse.UserInfoResponse getUserInfo(Long userId) {
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return UserConverter.toUserInfoResponse(user);
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/example/ssg_tab/global/apiPayload/status/ErrorStatus.java
@@ -27,6 +27,9 @@ public enum ErrorStatus implements BaseErrorCode {
     _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청한 자원을 찾을 수 없습니다."),
     _CONFLICT(HttpStatus.CONFLICT, "COMMON409", "요청이 서버 상태와 충돌합니다."),
 
+    // 토큰 관련 에러
+    INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH4001", "토큰이 유효하지 않습니다."),
+
     // 멤버 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "사용자가 없습니다.");
 

--- a/src/main/java/com/example/ssg_tab/global/auth/KakaoClient.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/KakaoClient.java
@@ -1,0 +1,34 @@
+package com.example.ssg_tab.global.auth;
+
+import com.example.ssg_tab.global.auth.info.KakaoTokenInfo;
+import com.example.ssg_tab.global.auth.info.KakaoUserInfo;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+@Component
+public class KakaoClient {
+
+    private final RestClient rest = RestClient.create();
+
+    public KakaoTokenInfo getTokenInfo(String accessToken) {
+        ResponseEntity<KakaoTokenInfo> res = rest.get()
+                .uri("https://kapi.kakao.com/v1/user/access_token_info")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .toEntity(KakaoTokenInfo.class);
+        return res.getBody();
+    }
+
+    public KakaoUserInfo getUserInfo(String accessToken) {
+        ResponseEntity<KakaoUserInfo> res = rest.get()
+                .uri("https://kapi.kakao.com/v2/user/me")
+                .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken)
+                .retrieve()
+                .toEntity(KakaoUserInfo.class);
+        return res.getBody();
+    }
+}
+
+

--- a/src/main/java/com/example/ssg_tab/global/auth/controller/AuthController.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/controller/AuthController.java
@@ -1,0 +1,39 @@
+package com.example.ssg_tab.global.auth.controller;
+
+import com.example.ssg_tab.global.auth.dto.AuthRequest;
+import com.example.ssg_tab.global.auth.dto.AuthResponse;
+import com.example.ssg_tab.global.auth.service.AuthService;
+import com.example.ssg_tab.global.apiPayload.ApiResponse;
+import com.example.ssg_tab.global.apiPayload.status.SuccessStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+@Tag(name = "Auth", description = "소셜 로그인, 인증 관련 API")
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping(value = "/login/kakao", produces = "application/json")
+    @Operation(summary = "카카오 로그인 API", description = "카카오를 통해 소셜 로그인/회원가입 후 토큰 발급")
+    public ApiResponse<AuthResponse.LoginResponse> login(@RequestBody @Valid AuthRequest.KakaoLoginRequest request){
+
+        AuthResponse.LoginResponse response = authService.kakaoLogin(request);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    @PostMapping("/reissue")
+    @Operation(summary = "토큰 재발급 API", description = "리프레쉬 토큰을 이용해 토큰을 재발급")
+    public ApiResponse<AuthResponse.LoginResponse> reissue(@RequestBody @Valid AuthRequest.RefreshTokenRequest request) {
+
+        AuthResponse.LoginResponse response = authService.reissue(request);
+
+        return ApiResponse.of(SuccessStatus._OK, response);
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/auth/converter/AuthConverter.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/converter/AuthConverter.java
@@ -1,0 +1,14 @@
+package com.example.ssg_tab.global.auth.converter;
+
+import com.example.ssg_tab.global.auth.dto.AuthResponse;
+
+public class AuthConverter {
+
+    public static AuthResponse.LoginResponse toLoginResponse(String accessToken, String refreshToken) {
+        return AuthResponse.LoginResponse.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/ssg_tab/global/auth/dto/AuthRequest.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/dto/AuthRequest.java
@@ -1,0 +1,36 @@
+package com.example.ssg_tab.global.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthRequest {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(title = "카카오 로그인 요청")
+    public static class KakaoLoginRequest {
+
+        @Schema(description = "카카오에서 발급받은 액세스 토큰")
+        @NotBlank(message = "카카오 액세스 토큰을 필수로 입력해주세요.")
+        private String kakaoAccessToken;
+
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(title = "토큰 재발급 요청")
+    public static class RefreshTokenRequest {
+
+        @Schema(description = "로그인 시 서버에서 발급해준 리프레쉬 토큰")
+        @NotBlank(message = "리프레쉬 토큰을 필수로 입력해주세요.")
+        private String refreshToken;
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/auth/dto/AuthResponse.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/dto/AuthResponse.java
@@ -1,0 +1,26 @@
+package com.example.ssg_tab.global.auth.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class AuthResponse {
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(title = "로그인 응답")
+    public static class LoginResponse {
+
+        @Schema(description = "서버 발급 액세스 토큰")
+        private String accessToken;
+
+        @Schema(description = "서버 발급 리프레쉬 토큰")
+        private String refreshToken;
+
+    }
+
+}

--- a/src/main/java/com/example/ssg_tab/global/auth/info/KakaoTokenInfo.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/info/KakaoTokenInfo.java
@@ -1,0 +1,7 @@
+package com.example.ssg_tab.global.auth.info;
+
+public record KakaoTokenInfo(
+        Long id,          // 회원번호
+        Integer expires_in,
+        Integer app_id
+) {}

--- a/src/main/java/com/example/ssg_tab/global/auth/info/KakaoUserInfo.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/info/KakaoUserInfo.java
@@ -1,0 +1,38 @@
+package com.example.ssg_tab.global.auth.info;
+
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record KakaoUserInfo(
+        Long id,
+        Map<String,Object> kakao_account,
+        Map<String,Object> properties
+) {
+    @SuppressWarnings("unchecked")
+    private Map<String,Object> getProfile() {
+        if (kakao_account == null) return null;
+        Object p = kakao_account.get("profile");
+        return (p instanceof Map<?,?> m) ? (Map<String,Object>) m : null;
+    }
+
+    private static String asNonBlankString(Object value) {
+        return (value instanceof String str && !str.isBlank()) ? str : null;
+    }
+
+    public String getNickname() {
+        String n1 = asNonBlankString(getProfile() != null ? getProfile().get("nickname") : null);
+        if (n1 != null) return n1;
+        return asNonBlankString(properties != null ? properties.get("nickname") : null);
+    }
+
+    public String getEmail() {
+        return asNonBlankString(kakao_account != null ? kakao_account.get("email") : null);
+    }
+
+    public String getProfileImageUrl() {
+        String url = asNonBlankString(getProfile() != null ? getProfile().get("profile_image_url") : null); // 권장
+        if (url != null) return url;
+        return asNonBlankString(properties != null ? properties.get("profile_image") : null);         // 폴백(레거시)
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/service/AuthService.java
@@ -1,0 +1,79 @@
+package com.example.ssg_tab.global.auth.service;
+
+import com.example.ssg_tab.domain.user.service.UserService;
+import com.example.ssg_tab.global.apiPayload.status.ErrorStatus;
+import com.example.ssg_tab.global.auth.KakaoClient;
+import com.example.ssg_tab.global.exception.GeneralException;
+import com.example.ssg_tab.global.jwt.JwtTokenService;
+import com.example.ssg_tab.global.auth.info.KakaoUserInfo;
+import com.example.ssg_tab.global.auth.converter.AuthConverter;
+import com.example.ssg_tab.global.auth.dto.AuthRequest;
+import com.example.ssg_tab.global.auth.dto.AuthResponse;
+import com.example.ssg_tab.global.auth.info.KakaoTokenInfo;
+import com.example.ssg_tab.domain.user.entity.User;
+import com.example.ssg_tab.domain.user.repository.UserRepository;
+import com.example.ssg_tab.global.jwt.RefreshTokenStore;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtTokenService jwtTokenService;
+    private final RefreshTokenStore refreshStore;
+
+    private final KakaoClient kakaoClient;
+
+    private final UserRepository userRepository;
+    private final UserService userService;
+
+    @Value("${jwt.refresh-token-exp-days}") private long refreshExpDays;
+
+    @Transactional
+    public AuthResponse.LoginResponse kakaoLogin(AuthRequest.KakaoLoginRequest request) {
+        // 1. 카카오 토큰 유효성 확인
+        KakaoTokenInfo tokenInfo = kakaoClient.getTokenInfo(request.getKakaoAccessToken());
+        Long kakaoId = tokenInfo.id(); // 소셜 식별자
+
+        // 2. 사용자 정보 조회(닉네임/이메일)
+        KakaoUserInfo userInfo = kakaoClient.getUserInfo(request.getKakaoAccessToken());
+        String nickname = userInfo.getNickname();
+        String email = userInfo.getEmail(); // 동의 안했으면 null
+        String profileImageUrl = userInfo.getProfileImageUrl();
+
+        // 3. 회원 조회 후 없으면 생성
+        User user = userRepository.findBySocialId(kakaoId)
+                .orElseGet(() -> userService.createUser(userInfo));
+
+        // 4. Jwt 발급
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+        String refreshToken = jwtTokenService.createRefreshToken(user.getId());
+        refreshStore.save(user.getId(), refreshToken, refreshExpDays);
+
+        return AuthConverter.toLoginResponse(accessToken, refreshToken);
+    }
+
+    @Transactional
+    public AuthResponse.LoginResponse reissue(AuthRequest.RefreshTokenRequest request) {
+
+        String refreshToken = request.getRefreshToken();
+
+        var claims = jwtTokenService.parse(refreshToken).getPayload();
+        Long uid = claims.get("uid", Long.class);
+
+        // Redis에 저장된 최신 토큰과 비교(회전 방지)
+        String stored = refreshStore.get(uid);
+        if (stored == null || !stored.equals(refreshToken)) {
+            throw new GeneralException(ErrorStatus.INVALID_TOKEN);
+        }
+
+        String newAccess = jwtTokenService.createAccessToken(uid);
+        String newRefresh = jwtTokenService.createRefreshToken(uid);
+        refreshStore.save(uid, newRefresh, refreshExpDays);
+
+        return AuthConverter.toLoginResponse(newAccess, newRefresh);
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/config/RedisConfig.java
+++ b/src/main/java/com/example/ssg_tab/global/config/RedisConfig.java
@@ -1,0 +1,20 @@
+package com.example.ssg_tab.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+@Configuration
+public class RedisConfig {
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        return new LettuceConnectionFactory();
+    }
+
+    @Bean
+    public StringRedisTemplate stringRedisTemplate(RedisConnectionFactory cf) {
+        return new StringRedisTemplate(cf);
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/ssg_tab/global/config/SecurityConfig.java
@@ -1,12 +1,18 @@
 package com.example.ssg_tab.global.config;
 
+import com.example.ssg_tab.global.jwt.JwtAuthFilter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtAuthFilter jwtAuthFilter;
 
     @Bean
     SecurityFilterChain security(HttpSecurity http) throws Exception {
@@ -18,7 +24,8 @@ public class SecurityConfig {
                                 "/swagger-ui.html",     // 커스텀한 UI 진입점
                                 "/swagger-ui/**",       // UI 리소스
                                 "/api-docs/**",         // 커스텀한 api-docs 경로
-                                "/v3/api-docs/**"       // 혹시 모를 기본 경로도 함께 허용
+                                "/v3/api-docs/**",      // 혹시 모를 기본 경로도 함께 허용
+                                "/auth/**"              // 인증 경로
                         ).permitAll()
 
                         // 테스트용
@@ -26,9 +33,11 @@ public class SecurityConfig {
 
                         // 그 외는 인증 필요
                         .anyRequest().authenticated()
-                );
+                )
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
+
 }
 

--- a/src/main/java/com/example/ssg_tab/global/entity/BaseEntity.java
+++ b/src/main/java/com/example/ssg_tab/global/entity/BaseEntity.java
@@ -1,0 +1,24 @@
+package com.example.ssg_tab.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/example/ssg_tab/global/jwt/CustomUserDetailService.java
+++ b/src/main/java/com/example/ssg_tab/global/jwt/CustomUserDetailService.java
@@ -1,0 +1,32 @@
+package com.example.ssg_tab.global.jwt;
+
+import com.example.ssg_tab.domain.user.entity.User;
+import com.example.ssg_tab.domain.user.repository.UserRepository;
+import com.example.ssg_tab.global.apiPayload.status.ErrorStatus;
+import com.example.ssg_tab.global.exception.GeneralException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    // 유저 ID로 사용자 조회
+    @Override
+    public UserDetails loadUserByUsername(String userId) throws UsernameNotFoundException {
+
+        User user = userRepository.findById(Long.valueOf(userId))
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(String.valueOf(user.getId()))
+                .password("")
+                .roles(user.getRole().name())
+                .build();
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/jwt/JwtAuthFilter.java
+++ b/src/main/java/com/example/ssg_tab/global/jwt/JwtAuthFilter.java
@@ -1,0 +1,72 @@
+package com.example.ssg_tab.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final JwtTokenService jwtTokenService;
+    private final CustomUserDetailService customUserDetailService;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+
+        // 이미 인증된 상태면 패스
+        if (SecurityContextHolder.getContext().getAuthentication() == null) {
+            String token = jwtTokenService.resolveToken(request);
+
+            if (token != null) {
+                try {
+                    // 1. 파싱/검증
+                    Jws<Claims> jws = jwtTokenService.parse(token);
+                    Claims c = jws.getPayload();
+
+                    // 2. access 토큰만 인증 세션으로 사용
+                    if ("access".equals(c.getSubject())) {
+                        Long uid = (c.get("uid") instanceof Number n) ? n.longValue()
+                                : Long.valueOf(String.valueOf(c.get("uid")));
+
+                        // 3. DB에서 UserDetails 로드(권한 포함)
+                        UserDetails userDetails = customUserDetailService.loadUserByUsername(String.valueOf(uid));
+
+                        // 4. 정식 Authentication 생성
+                        UsernamePasswordAuthenticationToken auth =
+                                new UsernamePasswordAuthenticationToken(
+                                        userDetails, null, userDetails.getAuthorities());
+                        auth.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                        SecurityContextHolder.getContext().setAuthentication(auth);
+                    }
+                } catch (Exception e) {
+
+                }
+            }
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    // Swagger, auth 등은 필터 스킵
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        String path = request.getRequestURI();
+        return path.startsWith("/auth/")
+                || path.startsWith("/swagger-ui/")
+                || path.startsWith("/v3/api-docs/");
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/jwt/JwtTokenService.java
+++ b/src/main/java/com/example/ssg_tab/global/jwt/JwtTokenService.java
@@ -1,0 +1,123 @@
+package com.example.ssg_tab.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+
+@Component
+public class JwtTokenService {
+
+    @Value("${jwt.secret}")
+    private String secret;
+    @Value("${jwt.issuer}")
+    private String issuer;
+    @Value("${jwt.access-token-exp-min}")
+    private long accessExpMin;
+    @Value("${jwt.refresh-token-exp-days}")
+    private long refreshExpDays;
+
+    private Key key;
+
+    @PostConstruct
+    void init() {
+        // secret이 Base64인지/평문인지 자동 판단해서 키 생성
+        Key k;
+        try {
+            byte[] decoded = Decoders.BASE64.decode(secret);
+            k = Keys.hmacShaKeyFor(decoded);
+        } catch (IllegalArgumentException notBase64) {
+            // Base64 아니면 평문으로 간주
+            k = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        }
+        this.key = k;
+    }
+
+    public String createAccessToken(Long userId) {
+        Instant now = Instant.now();
+        Instant exp = now.plus(Duration.ofMinutes(accessExpMin));
+
+        return Jwts.builder()
+                .issuer(issuer)
+                .subject("access")
+                .claim("uid", userId)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(exp))
+                .signWith(key)
+                .compact();
+    }
+
+    public String createRefreshToken(Long userId) {
+        Instant now = Instant.now();
+        Instant exp = now.plus(Duration.ofDays(refreshExpDays));
+
+        return Jwts.builder()
+                .issuer(issuer)
+                .subject("refresh")
+                .claim("uid", userId)
+                .issuedAt(Date.from(now))
+                .expiration(Date.from(exp))
+                .signWith(key)
+                .compact();
+    }
+
+    // 토큰(액세스,리프레시 공통) 파싱, 서명/만료 검증
+    public Jws<Claims> parse(String token) {
+        return Jwts.parser()
+                .clockSkewSeconds(0)
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(token);
+    }
+
+    // 토큰 추출
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+        return null;
+    }
+
+    // 유효한 액세스 토큰인지
+    public boolean isValidAccessToken(String token) {
+        try {
+            Jws<Claims> jws = parse(token);
+            return !"refresh".equals(jws.getPayload().getSubject());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 유효한 리프레시 토큰인지
+    public boolean isValidRefreshToken(String token) {
+        try {
+            Jws<Claims> jws = parse(token);
+            return "refresh".equals(jws.getPayload().getSubject());
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    // 토큰에서 유저 ID(uid) 추출
+    public Long getUserId(String token) {
+        Jws<Claims> jws = parse(token);
+        Object uid = jws.getPayload().get("uid");
+        if (uid instanceof Number n) return n.longValue();
+        if (uid instanceof String s) return Long.parseLong(s);
+        throw new IllegalStateException("uid claim not found");
+    }
+}

--- a/src/main/java/com/example/ssg_tab/global/jwt/RefreshTokenStore.java
+++ b/src/main/java/com/example/ssg_tab/global/jwt/RefreshTokenStore.java
@@ -1,0 +1,28 @@
+package com.example.ssg_tab.global.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshTokenStore {
+
+    private final StringRedisTemplate redis;
+
+    private String key(Long userId) { return "refresh:" + userId; }
+
+    public void save(Long userId, String refreshToken, long days) {
+        redis.opsForValue().set(key(userId), refreshToken, Duration.ofDays(days));
+    }
+
+    public String get(Long userId) {
+        return redis.opsForValue().get(key(userId));
+    }
+
+    public void delete(Long userId) {
+        redis.delete(key(userId));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   application:
-    name: 9oormthonUniv-2025-seasonthon-team-54-be
+    name: ssg-tab
 
   profiles:
     # 실행 시 활성화할 프로파일은 외부에서 지정 (--spring.profiles.active=local 등)
@@ -12,6 +12,11 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /api-docs
+
+jwt:
+#  secret: ${JWT_SECRET}
+  access-token-exp-min: 60  # 60분
+  refresh-token-exp-days: 14    # 14일
 
 # 기본 로깅 레벨
 logging:


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #7 

## ✨ 작업 내용
> 카카오 로그인을 구현
> - 유저의 refreshToken 정보는 Redis에 저장하도록 구현하였습니다.
> - 카카오 정보가 제대로 조회되는 지 확인하기 위해 유저 정보 조회 API까지 구현하였습니다.

## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 카카오 로그인
- [ ] 유저 정보 조회 API

## 📸 스크린샷 (선택)
> 

## 💬 기타 참고 사항
> 노션에 application-local.yml 파일 수정되었습니다.
