### PR TITLE
[Feat] 로그인, 온보딩 분리

### DIFF
--- a/src/main/java/com/example/ssg_tab/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/controller/UserController.java
@@ -1,18 +1,19 @@
 package com.example.ssg_tab.domain.user.controller;
 
+import com.example.ssg_tab.domain.user.dto.request.UserRequest;
 import com.example.ssg_tab.domain.user.dto.response.UserResponse;
+import com.example.ssg_tab.domain.user.service.OnboardingService;
 import com.example.ssg_tab.domain.user.service.UserCreateService;
 import com.example.ssg_tab.domain.user.service.UserQueryService;
 import com.example.ssg_tab.global.apiPayload.ApiResponse;
 import com.example.ssg_tab.global.apiPayload.status.SuccessStatus;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,8 +21,8 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "User", description = "사용자 관련 API")
 public class UserController {
 
-    private final UserCreateService userCreateService;
     private final UserQueryService userQueryService;
+    private final OnboardingService onboardingService;
 
     @GetMapping(value = "/", produces = "application/json")
     @Operation(summary = "유저 정보 조회 API", description = "로그인한 사용자의 유저 정보를 조회합니다.")
@@ -31,5 +32,16 @@ public class UserController {
         UserResponse.UserInfoResponse response = userQueryService.getUserInfo(uid);
 
         return ApiResponse.of(SuccessStatus._OK, response);
+    }
+
+    @PostMapping(value = "/onboarding", produces = "application/json")
+    @Operation(summary = "사용자 온보딩 API", description = "온보딩에서 입력받은 사용자의 정보를 반영합니다.")
+    public ApiResponse<Object> onboarding(@AuthenticationPrincipal UserDetails userDetails,
+                                    @RequestBody @Valid UserRequest.OnboardingRequest request){
+
+        Long uid = Long.valueOf(userDetails.getUsername());
+        onboardingService.onboarding(uid, request);
+
+        return ApiResponse.of(SuccessStatus.ONBOARDING_SUCCESS, null);
     }
 }

--- a/src/main/java/com/example/ssg_tab/domain/user/dto/request/UserRequest.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/dto/request/UserRequest.java
@@ -1,0 +1,50 @@
+package com.example.ssg_tab.domain.user.dto.request;
+
+import com.example.ssg_tab.domain.user.entity.enums.AgeBand;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+public class UserRequest {
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "온보딩 입력값")
+    public static class OnboardingRequest {
+
+        @Schema(description = "사용자 닉네임 - 이메일 회원가입 유저 사용")
+        private String nickname;
+
+        @Schema(description = "프로필 이미지 url - 이메일 회원가입 유저 사용")
+        private String profileImageUrl;
+
+        @Schema(description = "연령대 ENUM")
+        @NotNull
+        private AgeBand ageBand;
+
+        @Schema(description = "거주지역")
+        @NotBlank
+        private String region;
+
+        @Schema(description = "직업군")
+        @NotBlank
+        private String job;
+
+        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
+        @NotNull
+        @Size(min = 3, max = 5)
+        private List<Long> categoryIds;
+
+    }
+
+
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/dto/response/UserResponse.java
@@ -30,4 +30,5 @@ public class UserResponse {
         private String profileImageUrl;
 
     }
+
 }

--- a/src/main/java/com/example/ssg_tab/domain/user/entity/User.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.example.ssg_tab.domain.user.entity;
 
 import com.example.ssg_tab.domain.user.entity.enums.AgeBand;
 import com.example.ssg_tab.domain.user.entity.enums.UserRole;
+import com.example.ssg_tab.domain.user.entity.enums.UserStep;
 import com.example.ssg_tab.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -34,14 +35,19 @@ public class User extends BaseEntity {
     private String profileImageUrl; // 프로필 이미지(카카오 로그인 시 기본)
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @Column(name = "age", length = 20)
     private AgeBand ageBand;    // 연령대(20대 초, 중, 후, 30대)
 
-    @Column(nullable = false, length = 255)
+    @Column(name = "region", length = 255)
     private String region;  //  거주지역
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "job", length = 100)
     private String job;     // 직업군
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(name = "step", nullable = false)
+    private UserStep step = UserStep.ONBOARDING;
 
     @Enumerated(EnumType.STRING)
     @Column(name = "role", nullable = false)
@@ -52,6 +58,30 @@ public class User extends BaseEntity {
 
     public void encodePassword(String password) {
         this.password = password;
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
+
+    public void updateProfileImageUrl(String profileImageUrl) {
+        this.profileImageUrl = profileImageUrl;
+    }
+
+    public void updateAgeBand(AgeBand ageBand) {
+        this.ageBand = ageBand;
+    }
+
+    public void updateRegion(String region) {
+        this.region = region;
+    }
+
+    public void updateJob(String job) {
+        this.job = job;
+    }
+
+    public void updateStep(UserStep step) {
+        this.step = step;
     }
 
 }

--- a/src/main/java/com/example/ssg_tab/domain/user/entity/enums/UserStep.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/entity/enums/UserStep.java
@@ -1,0 +1,6 @@
+package com.example.ssg_tab.domain.user.entity.enums;
+
+public enum UserStep {
+    ONBOARDING, // 온보딩 단계
+    MAIN,       // 메인 단계
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/service/OnboardingService.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/OnboardingService.java
@@ -1,0 +1,13 @@
+package com.example.ssg_tab.domain.user.service;
+
+import com.example.ssg_tab.domain.user.dto.request.UserRequest;
+import com.example.ssg_tab.domain.user.entity.User;
+
+import java.util.List;
+
+public interface OnboardingService {
+
+    void onboarding(Long userId, UserRequest.OnboardingRequest request);
+
+    void attachCategories(User user, List<Long> categories);
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/service/OnboardingServiceImpl.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/OnboardingServiceImpl.java
@@ -1,0 +1,80 @@
+package com.example.ssg_tab.domain.user.service;
+
+import com.example.ssg_tab.domain.category.entity.Category;
+import com.example.ssg_tab.domain.category.repository.CategoryRepository;
+import com.example.ssg_tab.domain.user.dto.request.UserRequest;
+import com.example.ssg_tab.domain.user.entity.User;
+import com.example.ssg_tab.domain.user.entity.enums.UserStep;
+import com.example.ssg_tab.domain.user.entity.mapping.UserCategory;
+import com.example.ssg_tab.domain.user.repository.UserCategoryRepository;
+import com.example.ssg_tab.domain.user.repository.UserRepository;
+import com.example.ssg_tab.global.apiPayload.status.ErrorStatus;
+import com.example.ssg_tab.global.exception.GeneralException;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class OnboardingServiceImpl implements OnboardingService {
+
+    private final UserRepository userRepository;
+    private final CategoryRepository categoryRepository;
+    private final UserCategoryRepository userCategoryRepository;
+
+    @Override
+    @Transactional
+    public void onboarding(Long userId, UserRequest.OnboardingRequest request) {
+
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId).orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
+
+        // 2. 사용자 단계 검사
+        if(user.getStep() != UserStep.ONBOARDING) throw new GeneralException(ErrorStatus.ONBOARDING_STEP_ERROR);
+
+        // 3. 온보딩 내용 업데이트
+        if(user.getSocialId() == null){ // 카카오 유저가 아닐 경우
+            user.updateNickname(request.getNickname());
+            user.updateProfileImageUrl(request.getProfileImageUrl());
+        }
+        user.updateRegion(request.getRegion());
+        user.updateAgeBand(request.getAgeBand());
+        user.updateJob(request.getJob());
+        attachCategories(user, request.getCategoryIds());
+
+        // 온보딩 성공 시 단계를 MAIN으로 설정
+        user.updateStep(UserStep.MAIN);
+
+        userRepository.save(user);
+    }
+
+    // 관심 카테고리 매핑 (3~5개)
+    @Transactional
+    public void attachCategories(User user, List<Long> categoryIds) {
+
+        // 1. 카테고리 개수 검증
+        var ids = new LinkedHashSet<>(Optional.ofNullable(categoryIds).orElse(List.of()));
+        if (ids.size() < 3 || ids.size() > 5) {
+            throw new GeneralException(ErrorStatus.INVALID_INTEREST_COUNT); // "관심 카테고리는 3~5개를 선택해야 합니다."
+        }
+
+        // 2. 존재하는 카테고리 로드
+        var categories = categoryRepository.findAllById(ids);
+
+        // 3. 연관관계 생성
+        for (Category c : categories) {
+            if (!userCategoryRepository.existsByUserIdAndCategoryId(user.getId(), c.getId())) {
+                userCategoryRepository.save(
+                        UserCategory.builder()
+                                .user(user)
+                                .category(c)
+                                .build()
+                );
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/ssg_tab/domain/user/service/UserCreateService.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/UserCreateService.java
@@ -12,5 +12,4 @@ public interface UserCreateService {
 
     User createUser(AuthRequest.EmailSignUpRequest userInfo);
 
-    void attachCategories(User user, List<Long> categories);
 }

--- a/src/main/java/com/example/ssg_tab/domain/user/service/UserCreateServiceImpl.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/UserCreateServiceImpl.java
@@ -28,8 +28,6 @@ import java.util.Optional;
 public class UserCreateServiceImpl implements UserCreateService {
 
     private final UserRepository userRepository;
-    private final CategoryRepository categoryRepository;
-    private final UserCategoryRepository userCategoryRepository;
     private final PasswordEncoder passwordEncoder;
     private final KakaoClient kakaoClient;
 
@@ -52,9 +50,6 @@ public class UserCreateServiceImpl implements UserCreateService {
                         .nickname(kakaoUserInfo.getNickname())
                         .socialId(kakaoUserInfo.id())
                         .profileImageUrl(kakaoUserInfo.getProfileImageUrl())
-//                        .ageBand(userInfo.getAgeBand())
-//                        .region(userInfo.getRegion())
-//                        .job(userInfo.getJob())
                         .step(UserStep.ONBOARDING)
                         .role(UserRole.USER)
                         .build());
@@ -80,11 +75,6 @@ public class UserCreateServiceImpl implements UserCreateService {
                         .email(userInfo.getEmail())
                         .password(null) // 아래 encode 해서 세팅
                         .socialId(null) // 이메일 회원가입 경로
-//                        .nickname(userInfo.getNickname())
-//                        .profileImageUrl(userInfo.getProfileImageUrl())
-//                        .ageBand(userInfo.getAgeBand())
-//                        .region(userInfo.getRegion())
-//                        .job(userInfo.getJob())
                         .step(UserStep.ONBOARDING)
                         .role(UserRole.USER)
                         .build());

--- a/src/main/java/com/example/ssg_tab/domain/user/service/UserCreateServiceImpl.java
+++ b/src/main/java/com/example/ssg_tab/domain/user/service/UserCreateServiceImpl.java
@@ -4,6 +4,7 @@ import com.example.ssg_tab.domain.category.entity.Category;
 import com.example.ssg_tab.domain.category.repository.CategoryRepository;
 import com.example.ssg_tab.domain.user.entity.User;
 import com.example.ssg_tab.domain.user.entity.enums.UserRole;
+import com.example.ssg_tab.domain.user.entity.enums.UserStep;
 import com.example.ssg_tab.domain.user.entity.mapping.UserCategory;
 import com.example.ssg_tab.domain.user.repository.UserCategoryRepository;
 import com.example.ssg_tab.domain.user.repository.UserRepository;
@@ -51,9 +52,10 @@ public class UserCreateServiceImpl implements UserCreateService {
                         .nickname(kakaoUserInfo.getNickname())
                         .socialId(kakaoUserInfo.id())
                         .profileImageUrl(kakaoUserInfo.getProfileImageUrl())
-                        .ageBand(userInfo.getAgeBand())
-                        .region(userInfo.getRegion())
-                        .job(userInfo.getJob())
+//                        .ageBand(userInfo.getAgeBand())
+//                        .region(userInfo.getRegion())
+//                        .job(userInfo.getJob())
+                        .step(UserStep.ONBOARDING)
                         .role(UserRole.USER)
                         .build());
 
@@ -72,45 +74,22 @@ public class UserCreateServiceImpl implements UserCreateService {
             throw new GeneralException(ErrorStatus.EMAIL_ALREADY_EXISTS);
         }
 
-        User user = User.builder()
-                .email(userInfo.getEmail())
-                .password(null) // 아래 encode 해서 세팅
-                .nickname(userInfo.getNickname())
-                .socialId(null) // 이메일 회원가입 경로
-                .profileImageUrl(userInfo.getProfileImageUrl())  // Todo: 프로필 이미지 등록 방법 필요(S3)
-                .ageBand(userInfo.getAgeBand())
-                .region(userInfo.getRegion())
-                .job(userInfo.getJob())
-                .role(UserRole.USER)
-                .build();
+        // 2. 없으면 생성
+        User user = userRepository.findByEmail(email)
+                .orElseGet(() -> User.builder()
+                        .email(userInfo.getEmail())
+                        .password(null) // 아래 encode 해서 세팅
+                        .socialId(null) // 이메일 회원가입 경로
+//                        .nickname(userInfo.getNickname())
+//                        .profileImageUrl(userInfo.getProfileImageUrl())
+//                        .ageBand(userInfo.getAgeBand())
+//                        .region(userInfo.getRegion())
+//                        .job(userInfo.getJob())
+                        .step(UserStep.ONBOARDING)
+                        .role(UserRole.USER)
+                        .build());
 
         user.encodePassword(passwordEncoder.encode(userInfo.getPassword()));
         return userRepository.save(user);
-    }
-
-    // 관심 카테고리 매핑 (3~5개)
-    @Transactional
-    public void attachCategories(User user, List<Long> categoryIds) {
-
-        // 1. 카테고리 개수 검증
-        var ids = new LinkedHashSet<>(Optional.ofNullable(categoryIds).orElse(List.of()));
-        if (ids.size() < 3 || ids.size() > 5) {
-            throw new GeneralException(ErrorStatus.INVALID_INTEREST_COUNT); // "관심 카테고리는 3~5개를 선택해야 합니다."
-        }
-
-        // 2. 존재하는 카테고리 로드
-        var categories = categoryRepository.findAllById(ids);
-
-        // 3. 연관관계 생성
-        for (Category c : categories) {
-            if (!userCategoryRepository.existsByUserIdAndCategoryId(user.getId(), c.getId())) {
-                userCategoryRepository.save(
-                        UserCategory.builder()
-                                .user(user)
-                                .category(c)
-                                .build()
-                );
-            }
-        }
     }
 }

--- a/src/main/java/com/example/ssg_tab/global/apiPayload/status/ErrorStatus.java
+++ b/src/main/java/com/example/ssg_tab/global/apiPayload/status/ErrorStatus.java
@@ -34,6 +34,7 @@ public enum ErrorStatus implements BaseErrorCode {
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER4001", "사용자가 없습니다."),
     EMAIL_ALREADY_EXISTS(HttpStatus.CONFLICT, "MEMBER4002","이미 가입된 이메일입니다."),
     INVALID_CREDENTIALS(HttpStatus.BAD_REQUEST, "MEMBER4003", "비밀번호가 올바르지 않습니다."),
+    ONBOARDING_STEP_ERROR(HttpStatus.BAD_REQUEST, "MEMBER4004", "사용자가 온보딩 단계가 아닙니다."),
 
     // 카테고리 관련 에러
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY4001","존재하지 않는 카테고리입니다."),

--- a/src/main/java/com/example/ssg_tab/global/apiPayload/status/SuccessStatus.java
+++ b/src/main/java/com/example/ssg_tab/global/apiPayload/status/SuccessStatus.java
@@ -11,7 +11,10 @@ import org.springframework.http.HttpStatus;
 public enum SuccessStatus implements BaseCode {
 
     // 일반적인 응답
-    _OK(HttpStatus.OK, "COMMON2000", "성공입니다.");
+    _OK(HttpStatus.OK, "COMMON2000", "성공입니다."),
+
+    // 온보딩 성공 응답
+    ONBOARDING_SUCCESS(HttpStatus.OK, "ONBOARDING2000", "온보딩 성공");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/ssg_tab/global/auth/controller/AuthController.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/controller/AuthController.java
@@ -28,8 +28,8 @@ public class AuthController {
         return ApiResponse.of(SuccessStatus._OK, response);
     }
 
-    @PostMapping(value = "/signup", produces = "application/json")
-    @Operation(summary = "이메일 회원가입 API", description = "이메일과 온보딩 정보 입력 후 회원가입")
+    @PostMapping(value = "/signup/email", produces = "application/json")
+    @Operation(summary = "이메일 회원가입 API", description = "이메일과 비밀번호 입력 후 회원가입")
     public ApiResponse<AuthResponse.SignUpResponse> signup(@RequestBody @Valid AuthRequest.EmailSignUpRequest request){
 
         AuthResponse.SignUpResponse response = authService.signUp(request);
@@ -49,9 +49,9 @@ public class AuthController {
 
     @PostMapping("/reissue")
     @Operation(summary = "토큰 재발급 API", description = "리프레쉬 토큰을 이용해 토큰을 재발급")
-    public ApiResponse<AuthResponse.LoginResponse> reissue(@RequestBody @Valid AuthRequest.RefreshTokenRequest request) {
+    public ApiResponse<AuthResponse.ReissueResponse> reissue(@RequestBody @Valid AuthRequest.RefreshTokenRequest request) {
 
-        AuthResponse.LoginResponse response = authService.reissue(request);
+        AuthResponse.ReissueResponse response = authService.reissue(request);
 
         return ApiResponse.of(SuccessStatus._OK, response);
     }

--- a/src/main/java/com/example/ssg_tab/global/auth/converter/AuthConverter.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/converter/AuthConverter.java
@@ -6,18 +6,28 @@ import com.example.ssg_tab.domain.user.entity.User;
 public class AuthConverter {
 
     // 로그인 응답값 생성
-    public static AuthResponse.LoginResponse toLoginResponse(String accessToken, String refreshToken) {
+    public static AuthResponse.LoginResponse toLoginResponse(User user, String accessToken, String refreshToken) {
         return AuthResponse.LoginResponse.builder()
+                .step(user.getStep())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    // 토큰 재발급 응답값 생성
+    public static AuthResponse.ReissueResponse toReissueResponse(String accessToken, String refreshToken) {
+        return AuthResponse.ReissueResponse.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
                 .build();
     }
 
     // 회원가입 응답값 생성
-    public static AuthResponse.SignUpResponse toSignUpResponse(User user) {
-
+    public static AuthResponse.SignUpResponse toSignUpResponse(User user, String accessToken, String refreshToken) {
         return AuthResponse.SignUpResponse.builder()
-                .userId(user.getId())
+                .step(user.getStep())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
                 .build();
     }
 

--- a/src/main/java/com/example/ssg_tab/global/auth/dto/AuthRequest.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/dto/AuthRequest.java
@@ -25,22 +25,22 @@ public class AuthRequest {
         @NotBlank(message = "카카오 액세스 토큰을 필수로 입력해주세요.")
         private String kakaoAccessToken;
 
-        @Schema(description = "연령대 ENUM")
-        @NotNull
-        private AgeBand ageBand;
-
-        @Schema(description = "거주지역")
-        @NotBlank
-        private String region;
-
-        @Schema(description = "직업군")
-        @NotBlank
-        private String job;
-
-        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
-        @NotNull
-        @Size(min = 3, max = 5)
-        private List<Long> categoryIds;
+//        @Schema(description = "연령대 ENUM")
+//        @NotNull
+//        private AgeBand ageBand;
+//
+//        @Schema(description = "거주지역")
+//        @NotBlank
+//        private String region;
+//
+//        @Schema(description = "직업군")
+//        @NotBlank
+//        private String job;
+//
+//        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
+//        @NotNull
+//        @Size(min = 3, max = 5)
+//        private List<Long> categoryIds;
 
     }
 
@@ -63,10 +63,6 @@ public class AuthRequest {
     @Schema(title = "이메일로 회원가입 요청")
     public static class EmailSignUpRequest {
 
-        @Schema(description = "사용자 닉네임")
-        @NotBlank
-        private String nickname;
-
         @Schema(description = "회원가입할 이메일")
         @NotBlank
         private String email;
@@ -75,25 +71,29 @@ public class AuthRequest {
         @NotBlank
         private String password;
 
-        @Schema(description = "연령대 ENUM")
-        @NotNull
-        private AgeBand ageBand;
-
-        @Schema(description = "거주지역")
-        @NotBlank
-        private String region;
-
-        @Schema(description = "직업군")
-        @NotBlank
-        private String job;
-
-        @Schema(description = "프로필 이미지 url")
-        private String profileImageUrl;
-
-        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
-        @NotNull
-        @Size(min = 3, max = 5)
-        private List<Long> categoryIds;
+//        @Schema(description = "사용자 닉네임")
+//        @NotBlank
+//        private String nickname;
+//
+//        @Schema(description = "프로필 이미지 url")
+//        private String profileImageUrl;
+//
+//        @Schema(description = "연령대 ENUM")
+//        @NotNull
+//        private AgeBand ageBand;
+//
+//        @Schema(description = "거주지역")
+//        @NotBlank
+//        private String region;
+//
+//        @Schema(description = "직업군")
+//        @NotBlank
+//        private String job;
+//
+//        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
+//        @NotNull
+//        @Size(min = 3, max = 5)
+//        private List<Long> categoryIds;
     }
 
     @Builder

--- a/src/main/java/com/example/ssg_tab/global/auth/dto/AuthRequest.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/dto/AuthRequest.java
@@ -25,23 +25,6 @@ public class AuthRequest {
         @NotBlank(message = "카카오 액세스 토큰을 필수로 입력해주세요.")
         private String kakaoAccessToken;
 
-//        @Schema(description = "연령대 ENUM")
-//        @NotNull
-//        private AgeBand ageBand;
-//
-//        @Schema(description = "거주지역")
-//        @NotBlank
-//        private String region;
-//
-//        @Schema(description = "직업군")
-//        @NotBlank
-//        private String job;
-//
-//        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
-//        @NotNull
-//        @Size(min = 3, max = 5)
-//        private List<Long> categoryIds;
-
     }
 
     @Builder
@@ -71,29 +54,6 @@ public class AuthRequest {
         @NotBlank
         private String password;
 
-//        @Schema(description = "사용자 닉네임")
-//        @NotBlank
-//        private String nickname;
-//
-//        @Schema(description = "프로필 이미지 url")
-//        private String profileImageUrl;
-//
-//        @Schema(description = "연령대 ENUM")
-//        @NotNull
-//        private AgeBand ageBand;
-//
-//        @Schema(description = "거주지역")
-//        @NotBlank
-//        private String region;
-//
-//        @Schema(description = "직업군")
-//        @NotBlank
-//        private String job;
-//
-//        @Schema(description = "관심분야 카테고리 id값 리스트(3~5개 선택)")
-//        @NotNull
-//        @Size(min = 3, max = 5)
-//        private List<Long> categoryIds;
     }
 
     @Builder

--- a/src/main/java/com/example/ssg_tab/global/auth/dto/AuthResponse.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/dto/AuthResponse.java
@@ -1,5 +1,6 @@
 package com.example.ssg_tab.global.auth.dto;
 
+import com.example.ssg_tab.domain.user.entity.enums.UserStep;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -14,6 +15,9 @@ public class AuthResponse {
     @NoArgsConstructor
     @Schema(title = "로그인 응답")
     public static class LoginResponse {
+
+        @Schema(description = "로그인 유저의 다음 단계(온보딩 or 메인화면)")
+        private UserStep step;
 
         @Schema(description = "서버 발급 액세스 토큰")
         private String accessToken;
@@ -30,9 +34,29 @@ public class AuthResponse {
     @Schema(title = "회원가입 응답")
     public static class SignUpResponse {
 
-        @Schema(description = "생성된 사용자의 id값")
-        private Long userId;
+        @Schema(description = "로그인 유저의 다음 단계(온보딩 or 메인화면)")
+        private UserStep step;
 
+        @Schema(description = "서버 발급 액세스 토큰")
+        private String accessToken;
+
+        @Schema(description = "서버 발급 리프레쉬 토큰")
+        private String refreshToken;
+
+    }
+
+    @Builder
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Schema(title = "토큰 재발급 응답")
+    public static class ReissueResponse {
+
+        @Schema(description = "재발급된 액세스 토큰")
+        private String accessToken;
+
+        @Schema(description = "재발급된 리프레쉬 토큰")
+        private String refreshToken;
     }
 
 }

--- a/src/main/java/com/example/ssg_tab/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/service/AuthService.java
@@ -36,14 +36,14 @@ public class AuthService {
         User user = userCreateService.createKakaoUser(request);
 
         // 2. 관심 카테고리 매핑
-        userCreateService.attachCategories(user, request.getCategoryIds());
+//        userCreateService.attachCategories(user, request.getCategoryIds());
 
         // 3. Jwt 발급
         String accessToken = jwtTokenService.createAccessToken(user.getId());
         String refreshToken = jwtTokenService.createRefreshToken(user.getId());
         refreshStore.save(user.getId(), refreshToken, refreshExpDays);
 
-        return AuthConverter.toLoginResponse(accessToken, refreshToken);
+        return AuthConverter.toLoginResponse(user, accessToken, refreshToken);
     }
 
     @Transactional
@@ -53,9 +53,14 @@ public class AuthService {
         User user = userCreateService.createUser(request);
 
         // 2. 관심 카테고리 매핑
-        userCreateService.attachCategories(user, request.getCategoryIds());
+//        userCreateService.attachCategories(user, request.getCategoryIds());
 
-        return AuthConverter.toSignUpResponse(user);
+        // 2. 토큰 발급
+        String accessToken = jwtTokenService.createAccessToken(user.getId());
+        String refreshToken = jwtTokenService.createRefreshToken(user.getId());
+        refreshStore.save(user.getId(), refreshToken, refreshExpDays);
+
+        return AuthConverter.toSignUpResponse(user, accessToken, refreshToken);
     }
 
     @Transactional
@@ -77,11 +82,11 @@ public class AuthService {
         String refreshToken = jwtTokenService.createRefreshToken(user.getId());
         refreshStore.save(user.getId(), refreshToken, refreshExpDays);
 
-        return AuthConverter.toLoginResponse(accessToken, refreshToken);
+        return AuthConverter.toLoginResponse(user, accessToken, refreshToken);
     }
 
     @Transactional
-    public AuthResponse.LoginResponse reissue(AuthRequest.RefreshTokenRequest request) {
+    public AuthResponse.ReissueResponse reissue(AuthRequest.RefreshTokenRequest request) {
 
         String refreshToken = request.getRefreshToken();
 
@@ -98,6 +103,6 @@ public class AuthService {
         String newRefresh = jwtTokenService.createRefreshToken(uid);
         refreshStore.save(uid, newRefresh, refreshExpDays);
 
-        return AuthConverter.toLoginResponse(newAccess, newRefresh);
+        return AuthConverter.toReissueResponse(newAccess, newRefresh);
     }
 }

--- a/src/main/java/com/example/ssg_tab/global/auth/service/AuthService.java
+++ b/src/main/java/com/example/ssg_tab/global/auth/service/AuthService.java
@@ -35,10 +35,7 @@ public class AuthService {
         // 1. 회원 조회 후 없으면 생성
         User user = userCreateService.createKakaoUser(request);
 
-        // 2. 관심 카테고리 매핑
-//        userCreateService.attachCategories(user, request.getCategoryIds());
-
-        // 3. Jwt 발급
+        // 2. Jwt 발급
         String accessToken = jwtTokenService.createAccessToken(user.getId());
         String refreshToken = jwtTokenService.createRefreshToken(user.getId());
         refreshStore.save(user.getId(), refreshToken, refreshExpDays);
@@ -51,9 +48,6 @@ public class AuthService {
 
         // 1. 유저 생성
         User user = userCreateService.createUser(request);
-
-        // 2. 관심 카테고리 매핑
-//        userCreateService.attachCategories(user, request.getCategoryIds());
 
         // 2. 토큰 발급
         String accessToken = jwtTokenService.createAccessToken(user.getId());


### PR DESCRIPTION
## 🔗 관련 이슈 (선택)
closes #19

## ✨ 작업 내용
> 유저 엔티티 필드에 step을 추가하여 로그인 시 유저의 단계가 ONBOARDING인지 MAIN인지 검사하여 온보딩 진행상태를 확인할 수 있도록 변경
> 사용자가 온보딩을 통해 정보를 업데이트 하도록 온보딩 api 추가
> 유저 생성 시 step을 ONBOARDING으로 설정하고, 온보딩 api 호출 시 MAIN으로 변경하도록 구현


## ✅ 코드 리뷰어 체크리스트
리뷰어가 확인해야할 부분
- [ ] 로그인, 회원가입 확인
- [ ] 온보딩 확인

## 📸 스크린샷 (선택)
> 없음

## 💬 기타 참고 사항
> 리뷰어에게 전할 참고 사항
